### PR TITLE
Refactor test assertions in ThreadObject and time tests to use CHECK instead of REQUIRE

### DIFF
--- a/lib/osal/freertos/Semaphore.cpp
+++ b/lib/osal/freertos/Semaphore.cpp
@@ -32,6 +32,8 @@
 
 #include "osal/Semaphore.h"
 
+#include "osal/Error.h"
+
 #include <FreeRTOSConfig.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>

--- a/lib/osal/freertos/Thread.cpp
+++ b/lib/osal/freertos/Thread.cpp
@@ -32,13 +32,13 @@
 
 #include "osal/Thread.h"
 
+#include "osal/Error.h"
 #include "osal/Semaphore.h"
 
 #include <FreeRTOSConfig.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-#include <algorithm>
 #include <cstring>
 
 /// Helper thread function which is used as a wrapper for OSAL thread function.

--- a/lib/osal/linux/Semaphore.cpp
+++ b/lib/osal/linux/Semaphore.cpp
@@ -30,6 +30,8 @@
 
 #include "osal/Error.h"
 
+#include <semaphore.h>
+
 #include <cassert>
 #include <cerrno>
 #include <chrono>

--- a/lib/osal/linux/Thread.cpp
+++ b/lib/osal/linux/Thread.cpp
@@ -30,6 +30,7 @@
 
 #include "osal/Error.h"
 
+#include <pthread.h>
 #include <sched.h>
 
 #include <algorithm>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,14 +6,14 @@ add_executable(osal-tests
     main.cpp
     Mutex.cpp
     MutexObject.cpp
-    # ScopedLock.cpp
-    # Semaphore.cpp
-    # SemaphoreObject.cpp
-    # Thread.cpp
-    # ThreadObject.cpp
-    # time.cpp
-    # Timeout.cpp
-    # timestamp.cpp
+    ScopedLock.cpp
+    Semaphore.cpp
+    SemaphoreObject.cpp
+    Thread.cpp
+    ThreadObject.cpp
+    time.cpp
+    Timeout.cpp
+    timestamp.cpp
 )
 
 find_package(Catch2)

--- a/tests/ScopedLock.cpp
+++ b/tests/ScopedLock.cpp
@@ -34,6 +34,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <chrono>
+
 TEST_CASE("Create and destroy lock", "[unit][cpp][mutex]")
 {
     osal::Mutex mutex;
@@ -41,11 +43,11 @@ TEST_CASE("Create and destroy lock", "[unit][cpp][mutex]")
     bool locked = lock;
     bool acquired = lock.isAcquired();
 
-    REQUIRE(locked);
-    REQUIRE(acquired);
+    CHECK(locked);
+    CHECK(acquired);
 
     auto error = mutex.tryLock();
-    REQUIRE(error == OsalError::eLocked);
+    CHECK(error == OsalError::Locked);
 }
 
 TEST_CASE("Create lock with timeout", "[unit][cpp][mutex]")
@@ -55,16 +57,16 @@ TEST_CASE("Create lock with timeout", "[unit][cpp][mutex]")
     {
         osal::ScopedLock lock(mutex, 100ms);
         bool locked = lock;
-        REQUIRE(locked);
+        CHECK(locked);
     }
 
     auto error = mutex.lock();
-    REQUIRE(!error);
+    REQUIRE_FALSE(error);
 
     {
         osal::ScopedLock lock(mutex, 100ms);
         bool locked = lock;
-        REQUIRE(!locked);
+        CHECK_FALSE(locked);
     }
 }
 
@@ -75,17 +77,17 @@ TEST_CASE("Unlock ScopedLock when destroyed", "[unit][cpp][mutex]")
     {
         osal::ScopedLock lock(mutex);
         bool locked = lock;
-        REQUIRE(locked);
+        CHECK(locked);
 
         auto error = mutex.tryLock();
-        REQUIRE(error == OsalError::eLocked);
+        CHECK(error == OsalError::Locked);
     }
 
     auto error = mutex.tryLock();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     error = mutex.unlock();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Non-recursive success waitLock() thread with ScopedLock in C++", "[unit][cpp][mutex]")
@@ -95,7 +97,7 @@ TEST_CASE("Non-recursive success waitLock() thread with ScopedLock in C++", "[un
 
     auto func = [&mutex, &threadError] {
         osal::ScopedLock lock(mutex, 500ms);
-        threadError = lock ? OsalError::eOk : OsalError::eTimeout;
+        threadError = lock ? std::error_code{} : OsalError::Timeout;
     };
 
     osal::Thread thread;
@@ -110,6 +112,6 @@ TEST_CASE("Non-recursive success waitLock() thread with ScopedLock in C++", "[un
     }
 
     auto error = thread.join();
-    REQUIRE(!error);
-    REQUIRE(!threadError);
+    CHECK_FALSE(error);
+    CHECK_FALSE(threadError);
 }

--- a/tests/Semaphore.cpp
+++ b/tests/Semaphore.cpp
@@ -34,6 +34,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <chrono>
+#include <cstdint>
+
 TEST_CASE("Semaphore creation and destruction", "[unit][c][semaphore]")
 {
     unsigned int initialValue{};
@@ -56,257 +59,246 @@ TEST_CASE("Semaphore creation and destruction", "[unit][c][semaphore]")
 
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, initialValue);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::InvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Invalid parameters to semaphore creation and destruction functions", "[unit][c][semaphore]")
 {
     auto error = osalSemaphoreCreate(nullptr, 3);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalSemaphoreDestroy(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Wait and signal from one thread, start with 1", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 1);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Wait and signal from one thread, start with 0", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 0);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Invalid arguments passed to semaphore functions in one thread", "[unit][c][semaphore]")
 {
     auto error = osalSemaphoreWait(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalSemaphoreTryWait(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalSemaphoreTryWaitIsr(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalSemaphoreTimedWait(nullptr, 3);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalSemaphoreSignal(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalSemaphoreSignalIsr(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Combination of wait and signal calls from one thread", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 4);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 3.
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 2.
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 1.
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 2.
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 1.
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 2.
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     // 3.
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     int count{};
-    while (osalSemaphoreTryWait(&semaphore) == OsalError::eOk)
+    while (!osalSemaphoreTryWait(&semaphore))
         ++count;
 
-    REQUIRE(count == 3);
+    CHECK(count == 3);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Increment semaphore to value bigger than the initial one", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 4);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     int firstCount{};
-    while (osalSemaphoreTryWait(&semaphore) == OsalError::eOk)
+    while (!osalSemaphoreTryWait(&semaphore))
         ++firstCount;
 
     constexpr int cFirstExpectedCount = 4;
-    REQUIRE(firstCount == cFirstExpectedCount);
+    CHECK(firstCount == cFirstExpectedCount);
 
     constexpr int cSecondExpectedCount = 16;
     for (int i = 0; i < cSecondExpectedCount; ++i) {
         error = osalSemaphoreSignal(&semaphore);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 
     int secondCount{};
-    while (osalSemaphoreTryWait(&semaphore) == OsalError::eOk)
+    while (!osalSemaphoreTryWait(&semaphore))
         ++secondCount;
 
-    REQUIRE(secondCount == cSecondExpectedCount);
+    CHECK(secondCount == cSecondExpectedCount);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Wait called from two threads", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 1);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        auto error = osalSemaphoreWait(&semaphore);
-        if (error != OsalError::eOk)
-            REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(osalSemaphoreWait(&semaphore));
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
 
-        error = osalSemaphoreSignal(&semaphore);
-        if (error != OsalError::eOk)
-            REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(osalSemaphoreSignal(&semaphore));
     };
 
     osal::Thread thread(func);
 
     osal::sleep(120ms);
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
-    thread.join();
+    CHECK_FALSE(thread.join());
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TryWait called from second thread", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 1);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        while (osalSemaphoreTryWait(&semaphore) != OsalError::eOk)
+        while (osalSemaphoreTryWait(&semaphore))
             osal::sleep(10ms);
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
 
-        auto error = osalSemaphoreSignal(&semaphore);
-        if (error != OsalError::eOk)
-            REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(osalSemaphoreSignal(&semaphore));
     };
 
     osal::Thread thread(func);
 
     osal::sleep(120ms);
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
-    thread.join();
+    CHECK_FALSE(thread.join());
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TryWait and signal called from ISR", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 1);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalSemaphoreTryWaitIsr(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        while (osalSemaphoreTryWaitIsr(&semaphore) != OsalError::eOk)
+        while (osalSemaphoreTryWaitIsr(&semaphore))
             osal::sleep(10ms);
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
 
-        auto error = osalSemaphoreSignal(&semaphore);
-        if (error != OsalError::eOk)
-            REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(osalSemaphoreSignal(&semaphore));
     };
 
     osal::Thread thread(func);
 
     osal::sleep(120ms);
     error = osalSemaphoreSignalIsr(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
-    thread.join();
+    CHECK_FALSE(thread.join());
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Multiple wait called one thread", "[unit][c][semaphore]")
@@ -332,18 +324,18 @@ TEST_CASE("Multiple wait called one thread", "[unit][c][semaphore]")
 
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, initialValue);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     for (unsigned int i = 0; i < initialValue; ++i) {
         error = osalSemaphoreWait(&semaphore);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 
     error = osalSemaphoreTryWait(&semaphore);
-    REQUIRE(error == OsalError::Locked);
+    CHECK(error == OsalError::Locked);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Multiple tryWait called one thread", "[unit][c][semaphore]")
@@ -369,18 +361,18 @@ TEST_CASE("Multiple tryWait called one thread", "[unit][c][semaphore]")
 
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, initialValue);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     for (unsigned int i = 0; i < initialValue; ++i) {
         error = osalSemaphoreTryWait(&semaphore);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 
     error = osalSemaphoreTryWait(&semaphore);
-    REQUIRE(error == OsalError::Locked);
+    CHECK(error == OsalError::Locked);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Multiple tryWait called from ISR", "[unit][c][semaphore]")
@@ -406,84 +398,79 @@ TEST_CASE("Multiple tryWait called from ISR", "[unit][c][semaphore]")
 
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, initialValue);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     for (unsigned int i = 0; i < initialValue; ++i) {
         error = osalSemaphoreTryWaitIsr(&semaphore);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 
     error = osalSemaphoreTryWaitIsr(&semaphore);
-    REQUIRE(error == OsalError::Locked);
+    CHECK(error == OsalError::Locked);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TimedWait called from second thread, timeout", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 1);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
         constexpr std::uint32_t cTimeoutMs = 100;
         auto error = osalSemaphoreTimedWait(&semaphore, cTimeoutMs);
-        if (error != OsalError::eTimeout)
-            REQUIRE(error == OsalError::eTimeout);
+        REQUIRE(error == OsalError::Timeout);
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
     };
 
     osal::Thread thread(func);
-    thread.join();
+    CHECK_FALSE(thread.join());
 
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TimedWait called from second thread, success", "[unit][c][semaphore]")
 {
     OsalSemaphore semaphore{};
     auto error = osalSemaphoreCreate(&semaphore, 1);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalSemaphoreWait(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
         constexpr std::uint32_t cTimeoutMs = 100;
-        if (auto error = osalSemaphoreTimedWait(&semaphore, cTimeoutMs))
-            REQUIRE(!error);
+        REQUIRE_FALSE(osalSemaphoreTimedWait(&semaphore, cTimeoutMs));
 
         auto end = osal::timestamp();
-        if ((end - start) > 100ms)
-            REQUIRE((end - start) <= 100ms);
+        REQUIRE((end - start) <= 100ms);
 
-        if (auto error = osalSemaphoreSignal(&semaphore))
-            REQUIRE(!error);
+        REQUIRE_FALSE(osalSemaphoreSignal(&semaphore));
     };
 
     osal::Thread thread(func);
     osal::sleep(50ms);
 
     error = osalSemaphoreSignal(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
-    thread.join();
+    CHECK_FALSE(thread.join());
 
     error = osalSemaphoreDestroy(&semaphore);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }

--- a/tests/SemaphoreObject.cpp
+++ b/tests/SemaphoreObject.cpp
@@ -34,6 +34,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <chrono>
 #include <utility>
 
 TEST_CASE("Semaphore creation and destruction in C++", "[unit][cpp][semaphore]")
@@ -60,26 +61,26 @@ TEST_CASE("Semaphore creation and destruction in C++", "[unit][cpp][semaphore]")
 
     if (initialValue != 0) {
         auto error = semaphore.wait();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     auto error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Moving semaphore around in C++", "[unit][cpp][semaphore]")
 {
     osal::Semaphore semaphore(1);
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     osal::Semaphore semaphore2(std::move(semaphore));
 
     error = semaphore.signal(); // NOLINT
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = semaphore2.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Wait and signal from one thread in C++, start with 1", "[unit][cpp][semaphore]")
@@ -87,10 +88,10 @@ TEST_CASE("Wait and signal from one thread in C++, start with 1", "[unit][cpp][s
     osal::Semaphore semaphore(1);
 
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Wait and signal from one thread in C++, start with 0", "[unit][cpp][semaphore]")
@@ -98,10 +99,10 @@ TEST_CASE("Wait and signal from one thread in C++, start with 0", "[unit][cpp][s
     osal::Semaphore semaphore(0);
 
     auto error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Combination of wait and signal calls from one thread in C++", "[unit][cpp][semaphore]")
@@ -110,60 +111,60 @@ TEST_CASE("Combination of wait and signal calls from one thread in C++", "[unit]
 
     // 3.
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     // 2.
     error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     // 1.
     error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     // 2.
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     // 1.
     error = semaphore.wait();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     // 2.
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     // 3.
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     int count{};
-    while (semaphore.tryWait() == OsalError::eOk)
+    while (!semaphore.tryWait())
         ++count;
 
-    REQUIRE(count == 3);
+    CHECK(count == 3);
 }
 
 TEST_CASE("Increment semaphore to value bigger than the initial one in C++", "[unit][cpp][semaphore]")
 {
     osal::Semaphore semaphore(4);
     int firstCount{};
-    while (semaphore.tryWait() == OsalError::eOk)
+    while (!semaphore.tryWait())
         ++firstCount;
 
     constexpr int cFirstExpectedCount = 4;
-    REQUIRE(firstCount == cFirstExpectedCount);
+    CHECK(firstCount == cFirstExpectedCount);
 
     constexpr int cSecondExpectedCount = 16;
     for (int i = 0; i < cSecondExpectedCount; ++i) {
         auto error = semaphore.signal();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     int secondCount{};
-    while (semaphore.tryWait() == OsalError::eOk)
+    while (!semaphore.tryWait())
         ++secondCount;
 
-    REQUIRE(secondCount == cSecondExpectedCount);
+    CHECK(secondCount == cSecondExpectedCount);
 }
 
 TEST_CASE("Wait called from two threads in C++", "[unit][cpp][semaphore]")
@@ -171,29 +172,24 @@ TEST_CASE("Wait called from two threads in C++", "[unit][cpp][semaphore]")
     osal::Semaphore semaphore(1);
 
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        auto error = semaphore.wait();
-        if (error != OsalError::eOk)
-            REQUIRE(!error);
+        REQUIRE_FALSE(semaphore.wait());
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
 
-        error = semaphore.signal();
-        if (error != OsalError::eOk)
-            REQUIRE(!error);
+        REQUIRE_FALSE(semaphore.signal());
     };
 
     osal::Thread thread(func);
 
     osal::sleep(120ms);
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TryWait called from second thread in C++", "[unit][cpp][semaphore]")
@@ -201,28 +197,25 @@ TEST_CASE("TryWait called from second thread in C++", "[unit][cpp][semaphore]")
     osal::Semaphore semaphore(1);
 
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        while (semaphore.tryWait() != OsalError::eOk)
+        while (semaphore.tryWait())
             osal::sleep(10ms);
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
 
-        auto error = semaphore.signal();
-        if (error != OsalError::eOk)
-            REQUIRE(!error);
+        REQUIRE_FALSE(semaphore.signal());
     };
 
     osal::Thread thread(func);
 
     osal::sleep(120ms);
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TryWait and signal called from ISR in C++", "[unit][cpp][semaphore]")
@@ -230,28 +223,25 @@ TEST_CASE("TryWait and signal called from ISR in C++", "[unit][cpp][semaphore]")
     osal::Semaphore semaphore(1);
 
     auto error = semaphore.tryWaitIsr();
-    REQUIRE(!error);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        while (semaphore.tryWaitIsr() != OsalError::eOk)
+        while (semaphore.tryWaitIsr())
             osal::sleep(10ms);
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
 
-        auto error = semaphore.signal();
-        if (error != OsalError::eOk)
-            REQUIRE(!error);
+        REQUIRE_FALSE(semaphore.signal());
     };
 
     osal::Thread thread(func);
 
     osal::sleep(120ms);
     error = semaphore.signalIsr();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Multiple wait called one thread in C++", "[unit][cpp][semaphore]")
@@ -279,11 +269,11 @@ TEST_CASE("Multiple wait called one thread in C++", "[unit][cpp][semaphore]")
 
     for (unsigned int i = 0; i < initialValue; ++i) {
         auto error = semaphore.wait();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     auto error = semaphore.tryWait();
-    REQUIRE(error == OsalError::Locked);
+    CHECK(error == OsalError::Locked);
 }
 
 TEST_CASE("Multiple tryWait called one thread in C++", "[unit][cpp][semaphore]")
@@ -311,11 +301,11 @@ TEST_CASE("Multiple tryWait called one thread in C++", "[unit][cpp][semaphore]")
 
     for (unsigned int i = 0; i < initialValue; ++i) {
         auto error = semaphore.tryWait();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     auto error = semaphore.tryWait();
-    REQUIRE(error == OsalError::Locked);
+    CHECK(error == OsalError::Locked);
 }
 
 TEST_CASE("Multiple tryWait called from ISR in C++", "[unit][cpp][semaphore]")
@@ -343,11 +333,11 @@ TEST_CASE("Multiple tryWait called from ISR in C++", "[unit][cpp][semaphore]")
 
     for (unsigned int i = 0; i < initialValue; ++i) {
         auto error = semaphore.tryWaitIsr();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     auto error = semaphore.tryWaitIsr();
-    REQUIRE(error == OsalError::Locked);
+    CHECK(error == OsalError::Locked);
 }
 
 TEST_CASE("TimedWait called from second thread in C++, timeout", "[unit][cpp][semaphore]")
@@ -355,25 +345,23 @@ TEST_CASE("TimedWait called from second thread in C++, timeout", "[unit][cpp][se
     osal::Semaphore semaphore(1);
 
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
         auto error = semaphore.timedWait(100ms);
-        if (error != OsalError::eTimeout)
-            REQUIRE(error == OsalError::eTimeout);
+        REQUIRE(error == OsalError::Timeout);
 
         auto end = osal::timestamp();
-        if ((end - start) < 100ms)
-            REQUIRE((end - start) >= 100ms);
+        REQUIRE((end - start) >= 100ms);
     };
 
     osal::Thread thread(func);
-    thread.join();
+    CHECK_FALSE(thread.join());
 
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("TimedWait called from second thread in C++, success", "[unit][cpp][semaphore]")
@@ -381,27 +369,24 @@ TEST_CASE("TimedWait called from second thread in C++, success", "[unit][cpp][se
     osal::Semaphore semaphore(1);
 
     auto error = semaphore.wait();
-    REQUIRE(!error);
+    REQUIRE_FALSE(error);
 
     auto func = [&semaphore] {
         auto start = osal::timestamp();
 
-        if (auto error = semaphore.timedWait(100ms))
-            REQUIRE(!error);
+        REQUIRE_FALSE(semaphore.timedWait(100ms));
 
         auto end = osal::timestamp();
-        if ((end - start) > 100ms)
-            REQUIRE((end - start) <= 100ms);
+        REQUIRE((end - start) <= 100ms);
 
-        if (auto error = semaphore.signal())
-            REQUIRE(!error);
+        REQUIRE_FALSE(semaphore.signal());
     };
 
     osal::Thread thread(func);
     osal::sleep(50ms);
 
     error = semaphore.signal();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Timeout used with semaphores", "[unit][cpp][semaphore]")
@@ -410,6 +395,6 @@ TEST_CASE("Timeout used with semaphores", "[unit][cpp][semaphore]")
 
     osal::Timeout timeout = 100ms;
     auto error = semaphore.timedWait(timeout);
-    REQUIRE(error == OsalError::eTimeout);
-    REQUIRE(timeout.isExpired());
+    CHECK(error == OsalError::Timeout);
+    CHECK(timeout.isExpired());
 }

--- a/tests/Thread.cpp
+++ b/tests/Thread.cpp
@@ -36,6 +36,7 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -51,16 +52,16 @@ TEST_CASE("Thread creation and destruction", "[unit][c][thread]")
     OsalThread thread{};
     auto error
         = osalThreadCreate(&thread, {cOsalThreadDefaultPriority, cOsalThreadDefaultStackSize, nullptr}, func, nullptr);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalThreadJoin(&thread);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalThreadDestroy(&thread);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalThreadDestroy(&thread);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Named thread creation and destruction", "[unit][c][thread]")
@@ -91,21 +92,21 @@ TEST_CASE("Named thread creation and destruction", "[unit][c][thread]")
                                     func,
                                     &threadData,
                                     setThreadName.data());
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     threadData.startSemaphore.signal();
     threadData.stopSemaphore.wait();
     std::string_view getThreadName{threadData.getThreadName.data(), std::strlen(threadData.getThreadName.data())};
-    REQUIRE_THAT(getThreadName.data(), Catch::Matchers::Equals(setThreadName.data()));
+    CHECK_THAT(getThreadName.data(), Catch::Matchers::Equals(setThreadName.data()));
 
     error = osalThreadJoin(&thread);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalThreadDestroy(&thread);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalThreadDestroy(&thread);
-    REQUIRE(error == OsalError::InvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Thread creation with invalid arguments", "[unit][c][thread]")
@@ -115,27 +116,27 @@ TEST_CASE("Thread creation with invalid arguments", "[unit][c][thread]")
     OsalThread thread{};
     auto error
         = osalThreadCreate(nullptr, {cOsalThreadDefaultPriority, cOsalThreadDefaultStackSize, nullptr}, func, nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalThreadCreate(&thread,
                              {cOsalThreadDefaultPriority, cOsalThreadDefaultStackSize, nullptr},
                              nullptr,
                              nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalThreadCreateEx(&thread,
                                {cOsalThreadDefaultPriority, cOsalThreadDefaultStackSize, nullptr},
                                func,
                                nullptr,
                                "0123456789ABCDEF");
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     constexpr int cInvalidPriority = 5;
     error = osalThreadCreate(&thread,
                              {static_cast<OsalThreadPriority>(cInvalidPriority), cOsalThreadDefaultStackSize, nullptr},
                              func,
                              nullptr);
-    REQUIRE(error == OsalError::InvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Multiple thread joins", "[unit][c][thread]")
@@ -145,16 +146,16 @@ TEST_CASE("Multiple thread joins", "[unit][c][thread]")
     OsalThread thread{};
     auto error
         = osalThreadCreate(&thread, {cOsalThreadDefaultPriority, cOsalThreadDefaultStackSize, nullptr}, func, nullptr);
-    REQUIRE(error == OsalError::eOk);
+    REQUIRE_FALSE(error);
 
     error = osalThreadJoin(&thread);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 
     error = osalThreadJoin(&thread);
-    REQUIRE(error == OsalError::OsError);
+    CHECK(error == OsalError::OsError);
 
     error = osalThreadDestroy(&thread);
-    REQUIRE(error == OsalError::eOk);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Join invalid thread", "[unit][c][thread]")
@@ -162,10 +163,10 @@ TEST_CASE("Join invalid thread", "[unit][c][thread]")
     OsalThread thread{};
 
     auto error = osalThreadJoin(&thread);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = osalThreadJoin(nullptr);
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Launch 5 threads and check their results", "[unit][c][thread]")
@@ -186,18 +187,18 @@ TEST_CASE("Launch 5 threads and check their results", "[unit][c][thread]")
                                       {cOsalThreadDefaultPriority, cOsalThreadDefaultStackSize, nullptr},
                                       func,
                                       &counters[i]);
-        REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(error);
     }
 
     for (std::size_t i = 0; i < threads.size(); ++i) {
         auto error = osalThreadJoin(&threads[i]);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
 
         auto counter = counters[i];
-        REQUIRE(counter == cIterationsCount);
+        CHECK(counter == cIterationsCount);
 
         error = osalThreadDestroy(&threads[i]);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 }
 
@@ -236,7 +237,7 @@ TEST_CASE("Launch 5 threads with different priorities and check their results", 
     for (std::size_t i = 0; i < threads.size(); ++i) {
         auto priority = static_cast<OsalThreadPriority>(i / 2);
         auto error = osalThreadCreate(&threads[i], {priority, cOsalThreadDefaultStackSize, nullptr}, func, &args[i]);
-        REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(error);
     }
 
     start = true; // NOLINT
@@ -245,31 +246,31 @@ TEST_CASE("Launch 5 threads with different priorities and check their results", 
 
     for (auto& thread : threads) {
         auto error = osalThreadJoin(&thread);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
 
         error = osalThreadDestroy(&thread);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 
     for (auto counter : counters)
-        REQUIRE(counter != 0);
+        CHECK(counter != 0);
 }
 
 TEST_CASE("Create threads with all priorities", "[unit][c][thread]")
 {
     auto func = [](void* /*unused*/) { osal::sleep(1s); };
 
-    for (int i = OsalThreadPriority::eLowest; i <= OsalThreadPriority::eHighest; ++i) {
+    for (int i = OsalThreadPriority::Lowest; i <= OsalThreadPriority::Highest; ++i) {
         OsalThread thread{};
         auto priority = static_cast<OsalThreadPriority>(i / 2);
         auto error = osalThreadCreate(&thread, {priority, cOsalThreadDefaultStackSize, nullptr}, func, nullptr);
-        REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(error);
 
         error = osalThreadJoin(&thread);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
 
         error = osalThreadDestroy(&thread);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 }
 
@@ -294,8 +295,7 @@ TEST_CASE("Check if thread ids are unique and constant", "[unit][c][thread]")
         constexpr int cIterationsCount = 1000;
         for (int i = 0; i < cIterationsCount; ++i) {
             auto tmpId = osalThreadId();
-            if (tmpId != id)
-                REQUIRE(tmpId == id);
+            REQUIRE(tmpId == id);
 
             osalThreadYield();
         }
@@ -310,22 +310,22 @@ TEST_CASE("Check if thread ids are unique and constant", "[unit][c][thread]")
     for (std::size_t i = 0; i < threads.size(); ++i) {
         auto priority = static_cast<OsalThreadPriority>(i / 2);
         auto error = osalThreadCreate(&threads[i], {priority, cOsalThreadDefaultStackSize, nullptr}, func, &args[i]);
-        REQUIRE(error == OsalError::eOk);
+        REQUIRE_FALSE(error);
     }
 
     start = true; // NOLINT
 
     for (auto& thread : threads) {
         auto error = osalThreadJoin(&thread);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
 
         error = osalThreadDestroy(&thread);
-        REQUIRE(error == OsalError::eOk);
+        CHECK_FALSE(error);
     }
 
     std::set<std::uint32_t> uniqueIds;
     for (auto id : ids)
         uniqueIds.insert(id);
 
-    REQUIRE(uniqueIds.size() == cThreadsCount);
+    CHECK(uniqueIds.size() == cThreadsCount);
 }

--- a/tests/ThreadObject.cpp
+++ b/tests/ThreadObject.cpp
@@ -36,6 +36,7 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -64,17 +65,17 @@ TEST_CASE("Thread creation and destruction in C++", "[unit][cpp][thread]")
         osal::Thread thread(func, cParam);
 
         auto error = thread.join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     SECTION("Create thread via start() method")
     {
         osal::Thread thread;
         auto error = thread.start(func, cParam);
-        REQUIRE(!error);
+        REQUIRE_FALSE(error);
 
         error = thread.join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     SECTION("Start thread multiple times: via constructor and via start() method")
@@ -82,34 +83,34 @@ TEST_CASE("Thread creation and destruction in C++", "[unit][cpp][thread]")
         osal::Thread thread(func, cParam);
 
         auto error = thread.start(func, cParam);
-        REQUIRE(error == OsalError::eThreadAlreadyStarted);
+        CHECK(error == OsalError::ThreadAlreadyStarted);
 
         error = thread.join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
 
         osal::Thread thread2(func2);
 
         error = thread2.start(func2);
-        REQUIRE(error == OsalError::eThreadAlreadyStarted);
+        CHECK(error == OsalError::ThreadAlreadyStarted);
 
         error = thread2.join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
     SECTION("Start thread multiple times: 2 times via start() method")
     {
         osal::Thread thread;
         auto error = thread.start(func, cParam);
-        REQUIRE(!error);
+        REQUIRE_FALSE(error);
 
         error = thread.start(func, cParam);
-        REQUIRE(error == OsalError::eThreadAlreadyStarted);
+        CHECK(error == OsalError::ThreadAlreadyStarted);
 
         error = thread.join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
     }
 
-    REQUIRE(launched);
+    CHECK(launched);
 }
 
 TEST_CASE("Named thread creation and destruction", "[unit][cpp][thread]")
@@ -130,10 +131,10 @@ TEST_CASE("Named thread creation and destruction", "[unit][cpp][thread]")
 
     startSemaphore.signal();
     stopSemaphore.wait();
-    REQUIRE_THAT(getThreadName, Catch::Matchers::Equals(setThreadName.data()));
+    CHECK_THAT(getThreadName, Catch::Matchers::Equals(setThreadName.data()));
 
     auto error = thread.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 }
 
 TEST_CASE("Thread creation with custom stack", "[unit][cpp][thread]")
@@ -151,22 +152,22 @@ TEST_CASE("Thread creation with custom stack", "[unit][cpp][thread]")
         osal::Thread thread;
 
         auto error = thread.setStack(stack.data());
-        REQUIRE(!error);
+        CHECK_FALSE(error);
 
         error = thread.start(func);
-        REQUIRE(!error);
+        REQUIRE_FALSE(error);
 
         error = thread.join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
 
-        REQUIRE(launched);
+        CHECK(launched);
     }
 
     SECTION("Create thread with nullptr stack")
     {
         osal::Thread thread;
         auto error = thread.setStack(nullptr);
-        REQUIRE(error == OsalError::eInvalidArgument);
+        CHECK(error == OsalError::InvalidArgument);
     }
 }
 
@@ -211,8 +212,8 @@ TEST_CASE("Thread creation with variadic arguments", "[unit][cpp][thread]")
         expectedCounter = cExpectedCounter;
     }
 
-    REQUIRE(launched);
-    REQUIRE(counter == expectedCounter);
+    CHECK(launched);
+    CHECK(counter == expectedCounter);
 }
 
 TEST_CASE("Thread creation in C++ with different priorities", "[unit][cpp][thread]")
@@ -224,32 +225,32 @@ TEST_CASE("Thread creation in C++ with different priorities", "[unit][cpp][threa
         launched = true;
     };
 
-    SECTION("eLowest priority")
+    SECTION("Lowest priority")
     {
-        osal::Thread<OsalThreadPriority::eLowest> thread(func);
+        osal::Thread<OsalThreadPriority::Lowest> thread(func);
     }
 
-    SECTION("eLow priority")
+    SECTION("Low priority")
     {
-        osal::Thread<OsalThreadPriority::eLow> thread(func);
+        osal::Thread<OsalThreadPriority::Low> thread(func);
     }
 
-    SECTION("eNormal priority")
+    SECTION("Normal priority")
     {
-        osal::Thread<OsalThreadPriority::eNormal> thread(func);
+        osal::Thread<OsalThreadPriority::Normal> thread(func);
     }
 
-    SECTION("eHigh priority")
+    SECTION("High priority")
     {
-        osal::Thread<OsalThreadPriority::eHigh> thread(func);
+        osal::Thread<OsalThreadPriority::High> thread(func);
     }
 
-    SECTION("eHighest priority")
+    SECTION("Highest priority")
     {
-        osal::Thread<OsalThreadPriority::eHighest> thread(func);
+        osal::Thread<OsalThreadPriority::Highest> thread(func);
     }
 
-    REQUIRE(launched);
+    CHECK(launched);
 }
 
 TEST_CASE("Thread creation in C++ with different priorities using helper types", "[unit][cpp][thread]")
@@ -261,32 +262,32 @@ TEST_CASE("Thread creation in C++ with different priorities using helper types",
         launched = true;
     };
 
-    SECTION("eLowest priority")
+    SECTION("Lowest priority")
     {
         osal::LowestPrioThread<> thread(func);
     }
 
-    SECTION("eLow priority")
+    SECTION("Low priority")
     {
         osal::LowPrioThread<> thread(func);
     }
 
-    SECTION("eNormal priority")
+    SECTION("Normal priority")
     {
         osal::NormalPrioThread<> thread(func);
     }
 
-    SECTION("eHigh priority")
+    SECTION("High priority")
     {
         osal::HighPrioThread<> thread(func);
     }
 
-    SECTION("eHighest priority")
+    SECTION("Highest priority")
     {
         osal::HighestPrioThread<> thread(func);
     }
 
-    REQUIRE(launched);
+    CHECK(launched);
 }
 
 TEST_CASE("Move thread around", "[unit][cpp][thread]")
@@ -304,12 +305,12 @@ TEST_CASE("Move thread around", "[unit][cpp][thread]")
     osal::Thread thread2(std::move(thread1));
 
     auto error = thread1.join(); // NOLINT
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 
     error = thread2.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
-    REQUIRE(launched);
+    CHECK(launched);
 }
 
 TEST_CASE("Multiple thread joins in C++", "[unit][cpp][thread]")
@@ -319,10 +320,10 @@ TEST_CASE("Multiple thread joins in C++", "[unit][cpp][thread]")
     osal::Thread thread(func);
 
     auto error = thread.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     error = thread.join();
-    REQUIRE(error == OsalError::eOsError);
+    CHECK(error == OsalError::OsError);
 }
 
 TEST_CASE("Join invalid thread in C++", "[unit][cpp][thread]")
@@ -330,7 +331,7 @@ TEST_CASE("Join invalid thread in C++", "[unit][cpp][thread]")
     osal::Thread thread;
 
     auto error = thread.join();
-    REQUIRE(error == OsalError::eInvalidArgument);
+    CHECK(error == OsalError::InvalidArgument);
 }
 
 TEST_CASE("Launch 5 threads in C++ and check their results", "[unit][cpp][thread]")
@@ -347,15 +348,15 @@ TEST_CASE("Launch 5 threads in C++ and check their results", "[unit][cpp][thread
 
     for (std::size_t i = 0; i < threads.size(); ++i) {
         auto error = threads[i].start(func, std::ref(counters[i]));
-        REQUIRE(!error);
+        REQUIRE_FALSE(error);
     }
 
     for (std::size_t i = 0; i < threads.size(); ++i) {
         auto error = threads[i].join();
-        REQUIRE(!error);
+        CHECK_FALSE(error);
 
         auto counter = counters[i];
-        REQUIRE(counter == cIterationsCount);
+        CHECK(counter == cIterationsCount);
     }
 }
 
@@ -387,18 +388,18 @@ TEST_CASE("Launch 5 threads in C++ with different priorities and check their res
     stop = true; // NOLINT
 
     auto error = thread1.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread2.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread3.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread4.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread5.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     for (auto counter : counters)
-        REQUIRE(counter != 0);
+        CHECK(counter != 0);
 }
 
 TEST_CASE("Check if thread ids are unique and constant in C++", "[unit][cpp][thread]")
@@ -415,8 +416,7 @@ TEST_CASE("Check if thread ids are unique and constant in C++", "[unit][cpp][thr
         constexpr int cIterationsCount = 1000;
         for (int i = 0; i < cIterationsCount; ++i) {
             auto tmpId = osal::thread::id();
-            if (tmpId != id)
-                REQUIRE(tmpId == id);
+            REQUIRE(tmpId == id);
 
             osal::thread::yield();
         }
@@ -431,19 +431,19 @@ TEST_CASE("Check if thread ids are unique and constant in C++", "[unit][cpp][thr
     start = true; // NOLINT
 
     auto error = thread1.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread2.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread3.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread4.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
     error = thread5.join();
-    REQUIRE(!error);
+    CHECK_FALSE(error);
 
     std::set<std::uint32_t> uniqueIds;
     for (auto id : ids)
         uniqueIds.insert(id);
 
-    REQUIRE(uniqueIds.size() == cThreadsCount);
+    CHECK(uniqueIds.size() == cThreadsCount);
 }

--- a/tests/time.cpp
+++ b/tests/time.cpp
@@ -77,50 +77,50 @@ TEST_CASE("Convert to struct tm", "[unit][c][time]")
         std::transform(timevals.begin(), timevals.end(), tms.begin(), osalTimevalToTm);
     }
 
-    REQUIRE(tms[0].tm_mday == 28);
-    REQUIRE(tms[0].tm_mon == 0);
-    REQUIRE(tms[0].tm_year == 122);
-    REQUIRE(tms[0].tm_hour == 22);
-    REQUIRE(tms[0].tm_min == 13);
-    REQUIRE(tms[0].tm_sec == 2);
-    REQUIRE(tms[0].tm_wday == 5);
-    REQUIRE(tms[0].tm_yday == 27);
+    CHECK(tms[0].tm_mday == 28);
+    CHECK(tms[0].tm_mon == 0);
+    CHECK(tms[0].tm_year == 122);
+    CHECK(tms[0].tm_hour == 22);
+    CHECK(tms[0].tm_min == 13);
+    CHECK(tms[0].tm_sec == 2);
+    CHECK(tms[0].tm_wday == 5);
+    CHECK(tms[0].tm_yday == 27);
 
-    REQUIRE(tms[1].tm_mday == 14);
-    REQUIRE(tms[1].tm_mon == 7);
-    REQUIRE(tms[1].tm_year == 97);
-    REQUIRE(tms[1].tm_hour == 15);
-    REQUIRE(tms[1].tm_min == 5);
-    REQUIRE(tms[1].tm_sec == 45);
-    REQUIRE(tms[1].tm_wday == 4);
-    REQUIRE(tms[1].tm_yday == 225);
+    CHECK(tms[1].tm_mday == 14);
+    CHECK(tms[1].tm_mon == 7);
+    CHECK(tms[1].tm_year == 97);
+    CHECK(tms[1].tm_hour == 15);
+    CHECK(tms[1].tm_min == 5);
+    CHECK(tms[1].tm_sec == 45);
+    CHECK(tms[1].tm_wday == 4);
+    CHECK(tms[1].tm_yday == 225);
 
-    REQUIRE(tms[2].tm_mday == 31);
-    REQUIRE(tms[2].tm_mon == 11);
-    REQUIRE(tms[2].tm_year == 101);
-    REQUIRE(tms[2].tm_hour == 21);
-    REQUIRE(tms[2].tm_min == 6);
-    REQUIRE(tms[2].tm_sec == 17);
-    REQUIRE(tms[2].tm_wday == 1);
-    REQUIRE(tms[2].tm_yday == 364);
+    CHECK(tms[2].tm_mday == 31);
+    CHECK(tms[2].tm_mon == 11);
+    CHECK(tms[2].tm_year == 101);
+    CHECK(tms[2].tm_hour == 21);
+    CHECK(tms[2].tm_min == 6);
+    CHECK(tms[2].tm_sec == 17);
+    CHECK(tms[2].tm_wday == 1);
+    CHECK(tms[2].tm_yday == 364);
 
-    REQUIRE(tms[3].tm_mday == 11);
-    REQUIRE(tms[3].tm_mon == 8);
-    REQUIRE(tms[3].tm_year == 70);
-    REQUIRE(tms[3].tm_hour == 12);
-    REQUIRE(tms[3].tm_min == 0);
-    REQUIRE(tms[3].tm_sec == 0);
-    REQUIRE(tms[3].tm_wday == 5);
-    REQUIRE(tms[3].tm_yday == 253);
+    CHECK(tms[3].tm_mday == 11);
+    CHECK(tms[3].tm_mon == 8);
+    CHECK(tms[3].tm_year == 70);
+    CHECK(tms[3].tm_hour == 12);
+    CHECK(tms[3].tm_min == 0);
+    CHECK(tms[3].tm_sec == 0);
+    CHECK(tms[3].tm_wday == 5);
+    CHECK(tms[3].tm_yday == 253);
 
-    REQUIRE(tms[4].tm_mday == 8);
-    REQUIRE(tms[4].tm_mon == 7);
-    REQUIRE(tms[4].tm_year == 90);
-    REQUIRE(tms[4].tm_hour == 20);
-    REQUIRE(tms[4].tm_min == 20);
-    REQUIRE(tms[4].tm_sec == 0);
-    REQUIRE(tms[4].tm_wday == 3);
-    REQUIRE(tms[4].tm_yday == 219);
+    CHECK(tms[4].tm_mday == 8);
+    CHECK(tms[4].tm_mon == 7);
+    CHECK(tms[4].tm_year == 90);
+    CHECK(tms[4].tm_hour == 20);
+    CHECK(tms[4].tm_min == 20);
+    CHECK(tms[4].tm_sec == 0);
+    CHECK(tms[4].tm_wday == 3);
+    CHECK(tms[4].tm_yday == 219);
 }
 
 TEST_CASE("Convert to time_t", "[unit][c][time]")
@@ -196,11 +196,11 @@ TEST_CASE("Convert to time_t", "[unit][c][time]")
         std::transform(timevals.begin(), timevals.end(), times.begin(), osalTimevalToTime);
     }
 
-    REQUIRE(times[0] == cDate1);
-    REQUIRE(times[1] == cDate2);
-    REQUIRE(times[2] == cDate3);
-    REQUIRE(times[3] == cDate4);
-    REQUIRE(times[4] == cDate5);
+    CHECK(times[0] == cDate1);
+    CHECK(times[1] == cDate2);
+    CHECK(times[2] == cDate3);
+    CHECK(times[3] == cDate4);
+    CHECK(times[4] == cDate5);
 }
 
 TEST_CASE("Convert to struct timespec", "[unit][c][time]")
@@ -274,16 +274,16 @@ TEST_CASE("Convert to struct timespec", "[unit][c][time]")
         std::transform(timevals.begin(), timevals.end(), timespecs.begin(), osalTimevalToTimespec);
     }
 
-    REQUIRE(timespecs[0].tv_sec == cDate1);
-    REQUIRE(timespecs[0].tv_nsec == 0);
-    REQUIRE(timespecs[1].tv_sec == cDate2);
-    REQUIRE(timespecs[1].tv_nsec == 0);
-    REQUIRE(timespecs[2].tv_sec == cDate3);
-    REQUIRE(timespecs[2].tv_nsec == 0);
-    REQUIRE(timespecs[3].tv_sec == cDate4);
-    REQUIRE(timespecs[3].tv_nsec == 0);
-    REQUIRE(timespecs[4].tv_sec == cDate5);
-    REQUIRE(timespecs[4].tv_nsec == 0);
+    CHECK(timespecs[0].tv_sec == cDate1);
+    CHECK(timespecs[0].tv_nsec == 0);
+    CHECK(timespecs[1].tv_sec == cDate2);
+    CHECK(timespecs[1].tv_nsec == 0);
+    CHECK(timespecs[2].tv_sec == cDate3);
+    CHECK(timespecs[2].tv_nsec == 0);
+    CHECK(timespecs[3].tv_sec == cDate4);
+    CHECK(timespecs[3].tv_nsec == 0);
+    CHECK(timespecs[4].tv_sec == cDate5);
+    CHECK(timespecs[4].tv_nsec == 0);
 }
 
 TEST_CASE("Convert to struct timeval", "[unit][c][time]")
@@ -357,16 +357,16 @@ TEST_CASE("Convert to struct timeval", "[unit][c][time]")
         std::transform(timespecs.begin(), timespecs.end(), timevals.begin(), osalTimespecToTimeval);
     }
 
-    REQUIRE(timevals[0].tv_sec == cDate1);
-    REQUIRE(timevals[0].tv_usec == 0);
-    REQUIRE(timevals[1].tv_sec == cDate2);
-    REQUIRE(timevals[1].tv_usec == 0);
-    REQUIRE(timevals[2].tv_sec == cDate3);
-    REQUIRE(timevals[2].tv_usec == 0);
-    REQUIRE(timevals[3].tv_sec == cDate4);
-    REQUIRE(timevals[3].tv_usec == 0);
-    REQUIRE(timevals[4].tv_sec == cDate5);
-    REQUIRE(timevals[4].tv_usec == 0);
+    CHECK(timevals[0].tv_sec == cDate1);
+    CHECK(timevals[0].tv_usec == 0);
+    CHECK(timevals[1].tv_sec == cDate2);
+    CHECK(timevals[1].tv_usec == 0);
+    CHECK(timevals[2].tv_sec == cDate3);
+    CHECK(timevals[2].tv_usec == 0);
+    CHECK(timevals[3].tv_sec == cDate4);
+    CHECK(timevals[3].tv_usec == 0);
+    CHECK(timevals[4].tv_sec == cDate5);
+    CHECK(timevals[4].tv_usec == 0);
 }
 
 TEST_CASE("Convert to string", "[unit][c][time]")
@@ -426,17 +426,17 @@ TEST_CASE("Convert to string", "[unit][c][time]")
         tms[4].tm_yday = 219; // NOLINT
 
         for (std::size_t i = 0; i < tms.size(); ++i) {
-            auto error = osalTmToString(tms[i], time[i].data(), cSize, OsalTimeStringFormat::eTime);
-            REQUIRE(error == OsalError::eOk);
+            auto error = osalTmToString(tms[i], time[i].data(), cSize, OsalTimeStringFormat::Time);
+            CHECK_FALSE(error);
 
-            error = osalTmToString(tms[i], date[i].data(), cSize, OsalTimeStringFormat::eDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTmToString(tms[i], date[i].data(), cSize, OsalTimeStringFormat::Date);
+            CHECK_FALSE(error);
 
-            error = osalTmToString(tms[i], timeDate[i].data(), cSize, OsalTimeStringFormat::eTimeDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTmToString(tms[i], timeDate[i].data(), cSize, OsalTimeStringFormat::TimeDate);
+            CHECK_FALSE(error);
 
-            error = osalTmToString(tms[i], sortedDateTime[i].data(), cSize, OsalTimeStringFormat::eSortedDateTime);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTmToString(tms[i], sortedDateTime[i].data(), cSize, OsalTimeStringFormat::SortedDateTime);
+            CHECK_FALSE(error);
         }
     }
 
@@ -445,17 +445,17 @@ TEST_CASE("Convert to string", "[unit][c][time]")
         std::array<std::time_t, cDatesCount> times = {cDate1, cDate2, cDate3, cDate4, cDate5};
 
         for (std::size_t i = 0; i < times.size(); ++i) {
-            auto error = osalTimeToString(times[i], time[i].data(), cSize, OsalTimeStringFormat::eTime);
-            REQUIRE(error == OsalError::eOk);
+            auto error = osalTimeToString(times[i], time[i].data(), cSize, OsalTimeStringFormat::Time);
+            CHECK_FALSE(error);
 
-            error = osalTimeToString(times[i], date[i].data(), cSize, OsalTimeStringFormat::eDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimeToString(times[i], date[i].data(), cSize, OsalTimeStringFormat::Date);
+            CHECK_FALSE(error);
 
-            error = osalTimeToString(times[i], timeDate[i].data(), cSize, OsalTimeStringFormat::eTimeDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimeToString(times[i], timeDate[i].data(), cSize, OsalTimeStringFormat::TimeDate);
+            CHECK_FALSE(error);
 
-            error = osalTimeToString(times[i], sortedDateTime[i].data(), cSize, OsalTimeStringFormat::eSortedDateTime);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimeToString(times[i], sortedDateTime[i].data(), cSize, OsalTimeStringFormat::SortedDateTime);
+            CHECK_FALSE(error);
         }
     }
 
@@ -466,20 +466,20 @@ TEST_CASE("Convert to string", "[unit][c][time]")
         };
 
         for (std::size_t i = 0; i < timespecs.size(); ++i) {
-            auto error = osalTimespecToString(timespecs[i], time[i].data(), cSize, OsalTimeStringFormat::eTime);
-            REQUIRE(error == OsalError::eOk);
+            auto error = osalTimespecToString(timespecs[i], time[i].data(), cSize, OsalTimeStringFormat::Time);
+            CHECK_FALSE(error);
 
-            error = osalTimespecToString(timespecs[i], date[i].data(), cSize, OsalTimeStringFormat::eDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimespecToString(timespecs[i], date[i].data(), cSize, OsalTimeStringFormat::Date);
+            CHECK_FALSE(error);
 
-            error = osalTimespecToString(timespecs[i], timeDate[i].data(), cSize, OsalTimeStringFormat::eTimeDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimespecToString(timespecs[i], timeDate[i].data(), cSize, OsalTimeStringFormat::TimeDate);
+            CHECK_FALSE(error);
 
             error = osalTimespecToString(timespecs[i],
                                          sortedDateTime[i].data(),
                                          cSize,
-                                         OsalTimeStringFormat::eSortedDateTime);
-            REQUIRE(error == OsalError::eOk);
+                                         OsalTimeStringFormat::SortedDateTime);
+            CHECK_FALSE(error);
         }
     }
 
@@ -490,47 +490,47 @@ TEST_CASE("Convert to string", "[unit][c][time]")
         };
 
         for (std::size_t i = 0; i < timevals.size(); ++i) {
-            auto error = osalTimevalToString(timevals[i], time[i].data(), cSize, OsalTimeStringFormat::eTime);
-            REQUIRE(error == OsalError::eOk);
+            auto error = osalTimevalToString(timevals[i], time[i].data(), cSize, OsalTimeStringFormat::Time);
+            CHECK_FALSE(error);
 
-            error = osalTimevalToString(timevals[i], date[i].data(), cSize, OsalTimeStringFormat::eDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimevalToString(timevals[i], date[i].data(), cSize, OsalTimeStringFormat::Date);
+            CHECK_FALSE(error);
 
-            error = osalTimevalToString(timevals[i], timeDate[i].data(), cSize, OsalTimeStringFormat::eTimeDate);
-            REQUIRE(error == OsalError::eOk);
+            error = osalTimevalToString(timevals[i], timeDate[i].data(), cSize, OsalTimeStringFormat::TimeDate);
+            CHECK_FALSE(error);
 
             error = osalTimevalToString(timevals[i],
                                         sortedDateTime[i].data(),
                                         cSize,
-                                        OsalTimeStringFormat::eSortedDateTime);
-            REQUIRE(error == OsalError::eOk);
+                                        OsalTimeStringFormat::SortedDateTime);
+            CHECK_FALSE(error);
         }
     }
 
-    REQUIRE_THAT(time[0].data(), Catch::Matchers::Equals("22:13:02"));
-    REQUIRE_THAT(date[0].data(), Catch::Matchers::Equals("28.01.2022"));
-    REQUIRE_THAT(timeDate[0].data(), Catch::Matchers::Equals("22:13:02 28.01.2022"));
-    REQUIRE_THAT(sortedDateTime[0].data(), Catch::Matchers::Equals("20220128_221302"));
+    CHECK_THAT(time[0].data(), Catch::Matchers::Equals("22:13:02"));
+    CHECK_THAT(date[0].data(), Catch::Matchers::Equals("28.01.2022"));
+    CHECK_THAT(timeDate[0].data(), Catch::Matchers::Equals("22:13:02 28.01.2022"));
+    CHECK_THAT(sortedDateTime[0].data(), Catch::Matchers::Equals("20220128_221302"));
 
-    REQUIRE_THAT(time[1].data(), Catch::Matchers::Equals("15:05:45"));
-    REQUIRE_THAT(date[1].data(), Catch::Matchers::Equals("14.08.1997"));
-    REQUIRE_THAT(timeDate[1].data(), Catch::Matchers::Equals("15:05:45 14.08.1997"));
-    REQUIRE_THAT(sortedDateTime[1].data(), Catch::Matchers::Equals("19970814_150545"));
+    CHECK_THAT(time[1].data(), Catch::Matchers::Equals("15:05:45"));
+    CHECK_THAT(date[1].data(), Catch::Matchers::Equals("14.08.1997"));
+    CHECK_THAT(timeDate[1].data(), Catch::Matchers::Equals("15:05:45 14.08.1997"));
+    CHECK_THAT(sortedDateTime[1].data(), Catch::Matchers::Equals("19970814_150545"));
 
-    REQUIRE_THAT(time[2].data(), Catch::Matchers::Equals("21:06:17"));
-    REQUIRE_THAT(date[2].data(), Catch::Matchers::Equals("31.12.2001"));
-    REQUIRE_THAT(timeDate[2].data(), Catch::Matchers::Equals("21:06:17 31.12.2001"));
-    REQUIRE_THAT(sortedDateTime[2].data(), Catch::Matchers::Equals("20011231_210617"));
+    CHECK_THAT(time[2].data(), Catch::Matchers::Equals("21:06:17"));
+    CHECK_THAT(date[2].data(), Catch::Matchers::Equals("31.12.2001"));
+    CHECK_THAT(timeDate[2].data(), Catch::Matchers::Equals("21:06:17 31.12.2001"));
+    CHECK_THAT(sortedDateTime[2].data(), Catch::Matchers::Equals("20011231_210617"));
 
-    REQUIRE_THAT(time[3].data(), Catch::Matchers::Equals("12:00:00"));
-    REQUIRE_THAT(date[3].data(), Catch::Matchers::Equals("11.09.1970"));
-    REQUIRE_THAT(timeDate[3].data(), Catch::Matchers::Equals("12:00:00 11.09.1970"));
-    REQUIRE_THAT(sortedDateTime[3].data(), Catch::Matchers::Equals("19700911_120000"));
+    CHECK_THAT(time[3].data(), Catch::Matchers::Equals("12:00:00"));
+    CHECK_THAT(date[3].data(), Catch::Matchers::Equals("11.09.1970"));
+    CHECK_THAT(timeDate[3].data(), Catch::Matchers::Equals("12:00:00 11.09.1970"));
+    CHECK_THAT(sortedDateTime[3].data(), Catch::Matchers::Equals("19700911_120000"));
 
-    REQUIRE_THAT(time[4].data(), Catch::Matchers::Equals("20:20:00"));
-    REQUIRE_THAT(date[4].data(), Catch::Matchers::Equals("08.08.1990"));
-    REQUIRE_THAT(timeDate[4].data(), Catch::Matchers::Equals("20:20:00 08.08.1990"));
-    REQUIRE_THAT(sortedDateTime[4].data(), Catch::Matchers::Equals("19900808_202000"));
+    CHECK_THAT(time[4].data(), Catch::Matchers::Equals("20:20:00"));
+    CHECK_THAT(date[4].data(), Catch::Matchers::Equals("08.08.1990"));
+    CHECK_THAT(timeDate[4].data(), Catch::Matchers::Equals("20:20:00 08.08.1990"));
+    CHECK_THAT(sortedDateTime[4].data(), Catch::Matchers::Equals("19900808_202000"));
 }
 
 TEST_CASE("Convert to std::tm in C++", "[unit][cpp][time]")
@@ -565,50 +565,50 @@ TEST_CASE("Convert to std::tm in C++", "[unit][cpp][time]")
             tms[i] = osal::toTm(timevals[i]);
     }
 
-    REQUIRE(tms[0].tm_mday == 28);
-    REQUIRE(tms[0].tm_mon == 0);
-    REQUIRE(tms[0].tm_year == 122);
-    REQUIRE(tms[0].tm_hour == 22);
-    REQUIRE(tms[0].tm_min == 13);
-    REQUIRE(tms[0].tm_sec == 2);
-    REQUIRE(tms[0].tm_wday == 5);
-    REQUIRE(tms[0].tm_yday == 27);
+    CHECK(tms[0].tm_mday == 28);
+    CHECK(tms[0].tm_mon == 0);
+    CHECK(tms[0].tm_year == 122);
+    CHECK(tms[0].tm_hour == 22);
+    CHECK(tms[0].tm_min == 13);
+    CHECK(tms[0].tm_sec == 2);
+    CHECK(tms[0].tm_wday == 5);
+    CHECK(tms[0].tm_yday == 27);
 
-    REQUIRE(tms[1].tm_mday == 14);
-    REQUIRE(tms[1].tm_mon == 7);
-    REQUIRE(tms[1].tm_year == 97);
-    REQUIRE(tms[1].tm_hour == 15);
-    REQUIRE(tms[1].tm_min == 5);
-    REQUIRE(tms[1].tm_sec == 45);
-    REQUIRE(tms[1].tm_wday == 4);
-    REQUIRE(tms[1].tm_yday == 225);
+    CHECK(tms[1].tm_mday == 14);
+    CHECK(tms[1].tm_mon == 7);
+    CHECK(tms[1].tm_year == 97);
+    CHECK(tms[1].tm_hour == 15);
+    CHECK(tms[1].tm_min == 5);
+    CHECK(tms[1].tm_sec == 45);
+    CHECK(tms[1].tm_wday == 4);
+    CHECK(tms[1].tm_yday == 225);
 
-    REQUIRE(tms[2].tm_mday == 31);
-    REQUIRE(tms[2].tm_mon == 11);
-    REQUIRE(tms[2].tm_year == 101);
-    REQUIRE(tms[2].tm_hour == 21);
-    REQUIRE(tms[2].tm_min == 6);
-    REQUIRE(tms[2].tm_sec == 17);
-    REQUIRE(tms[2].tm_wday == 1);
-    REQUIRE(tms[2].tm_yday == 364);
+    CHECK(tms[2].tm_mday == 31);
+    CHECK(tms[2].tm_mon == 11);
+    CHECK(tms[2].tm_year == 101);
+    CHECK(tms[2].tm_hour == 21);
+    CHECK(tms[2].tm_min == 6);
+    CHECK(tms[2].tm_sec == 17);
+    CHECK(tms[2].tm_wday == 1);
+    CHECK(tms[2].tm_yday == 364);
 
-    REQUIRE(tms[3].tm_mday == 11);
-    REQUIRE(tms[3].tm_mon == 8);
-    REQUIRE(tms[3].tm_year == 70);
-    REQUIRE(tms[3].tm_hour == 12);
-    REQUIRE(tms[3].tm_min == 0);
-    REQUIRE(tms[3].tm_sec == 0);
-    REQUIRE(tms[3].tm_wday == 5);
-    REQUIRE(tms[3].tm_yday == 253);
+    CHECK(tms[3].tm_mday == 11);
+    CHECK(tms[3].tm_mon == 8);
+    CHECK(tms[3].tm_year == 70);
+    CHECK(tms[3].tm_hour == 12);
+    CHECK(tms[3].tm_min == 0);
+    CHECK(tms[3].tm_sec == 0);
+    CHECK(tms[3].tm_wday == 5);
+    CHECK(tms[3].tm_yday == 253);
 
-    REQUIRE(tms[4].tm_mday == 8);
-    REQUIRE(tms[4].tm_mon == 7);
-    REQUIRE(tms[4].tm_year == 90);
-    REQUIRE(tms[4].tm_hour == 20);
-    REQUIRE(tms[4].tm_min == 20);
-    REQUIRE(tms[4].tm_sec == 0);
-    REQUIRE(tms[4].tm_wday == 3);
-    REQUIRE(tms[4].tm_yday == 219);
+    CHECK(tms[4].tm_mday == 8);
+    CHECK(tms[4].tm_mon == 7);
+    CHECK(tms[4].tm_year == 90);
+    CHECK(tms[4].tm_hour == 20);
+    CHECK(tms[4].tm_min == 20);
+    CHECK(tms[4].tm_sec == 0);
+    CHECK(tms[4].tm_wday == 3);
+    CHECK(tms[4].tm_yday == 219);
 }
 
 TEST_CASE("Convert to std::time_t in C++", "[unit][cpp][time]")
@@ -687,11 +687,11 @@ TEST_CASE("Convert to std::time_t in C++", "[unit][cpp][time]")
             times[i] = osal::toTime(timevals[i]);
     }
 
-    REQUIRE(times[0] == cDate1);
-    REQUIRE(times[1] == cDate2);
-    REQUIRE(times[2] == cDate3);
-    REQUIRE(times[3] == cDate4);
-    REQUIRE(times[4] == cDate5);
+    CHECK(times[0] == cDate1);
+    CHECK(times[1] == cDate2);
+    CHECK(times[2] == cDate3);
+    CHECK(times[3] == cDate4);
+    CHECK(times[4] == cDate5);
 }
 
 TEST_CASE("Convert to std::timespec in C++", "[unit][cpp][time]")
@@ -768,16 +768,16 @@ TEST_CASE("Convert to std::timespec in C++", "[unit][cpp][time]")
             timespecs[i] = osal::toTimespec(timevals[i]);
     }
 
-    REQUIRE(timespecs[0].tv_sec == cDate1);
-    REQUIRE(timespecs[0].tv_nsec == 0);
-    REQUIRE(timespecs[1].tv_sec == cDate2);
-    REQUIRE(timespecs[1].tv_nsec == 0);
-    REQUIRE(timespecs[2].tv_sec == cDate3);
-    REQUIRE(timespecs[2].tv_nsec == 0);
-    REQUIRE(timespecs[3].tv_sec == cDate4);
-    REQUIRE(timespecs[3].tv_nsec == 0);
-    REQUIRE(timespecs[4].tv_sec == cDate5);
-    REQUIRE(timespecs[4].tv_nsec == 0);
+    CHECK(timespecs[0].tv_sec == cDate1);
+    CHECK(timespecs[0].tv_nsec == 0);
+    CHECK(timespecs[1].tv_sec == cDate2);
+    CHECK(timespecs[1].tv_nsec == 0);
+    CHECK(timespecs[2].tv_sec == cDate3);
+    CHECK(timespecs[2].tv_nsec == 0);
+    CHECK(timespecs[3].tv_sec == cDate4);
+    CHECK(timespecs[3].tv_nsec == 0);
+    CHECK(timespecs[4].tv_sec == cDate5);
+    CHECK(timespecs[4].tv_nsec == 0);
 }
 
 TEST_CASE("Convert to std::timeval in C++", "[unit][cpp][time]")
@@ -854,16 +854,16 @@ TEST_CASE("Convert to std::timeval in C++", "[unit][cpp][time]")
             timevals[i] = osal::toTimeval(timespecs[i]);
     }
 
-    REQUIRE(timevals[0].tv_sec == cDate1);
-    REQUIRE(timevals[0].tv_usec == 0);
-    REQUIRE(timevals[1].tv_sec == cDate2);
-    REQUIRE(timevals[1].tv_usec == 0);
-    REQUIRE(timevals[2].tv_sec == cDate3);
-    REQUIRE(timevals[2].tv_usec == 0);
-    REQUIRE(timevals[3].tv_sec == cDate4);
-    REQUIRE(timevals[3].tv_usec == 0);
-    REQUIRE(timevals[4].tv_sec == cDate5);
-    REQUIRE(timevals[4].tv_usec == 0);
+    CHECK(timevals[0].tv_sec == cDate1);
+    CHECK(timevals[0].tv_usec == 0);
+    CHECK(timevals[1].tv_sec == cDate2);
+    CHECK(timevals[1].tv_usec == 0);
+    CHECK(timevals[2].tv_sec == cDate3);
+    CHECK(timevals[2].tv_usec == 0);
+    CHECK(timevals[3].tv_sec == cDate4);
+    CHECK(timevals[3].tv_usec == 0);
+    CHECK(timevals[4].tv_sec == cDate5);
+    CHECK(timevals[4].tv_usec == 0);
 }
 
 TEST_CASE("Convert to std::string in C++", "[unit][cpp][time]")
@@ -922,10 +922,10 @@ TEST_CASE("Convert to std::string in C++", "[unit][cpp][time]")
         tms[4].tm_yday = 219; // NOLINT
 
         for (std::size_t i = 0; i < tms.size(); ++i) {
-            time[i] = osal::toString(tms[i], OsalTimeStringFormat::eTime);
-            date[i] = osal::toString(tms[i], OsalTimeStringFormat::eDate);
-            timeDate[i] = osal::toString(tms[i], OsalTimeStringFormat::eTimeDate);
-            sortedDateTime[i] = osal::toString(tms[i], OsalTimeStringFormat::eSortedDateTime);
+            time[i] = osal::toString(tms[i], OsalTimeStringFormat::Time);
+            date[i] = osal::toString(tms[i], OsalTimeStringFormat::Date);
+            timeDate[i] = osal::toString(tms[i], OsalTimeStringFormat::TimeDate);
+            sortedDateTime[i] = osal::toString(tms[i], OsalTimeStringFormat::SortedDateTime);
         }
     }
 
@@ -934,10 +934,10 @@ TEST_CASE("Convert to std::string in C++", "[unit][cpp][time]")
         std::array<std::time_t, cDatesCount> times = {cDate1, cDate2, cDate3, cDate4, cDate5};
 
         for (std::size_t i = 0; i < times.size(); ++i) {
-            time[i] = osal::toString(times[i], OsalTimeStringFormat::eTime);
-            date[i] = osal::toString(times[i], OsalTimeStringFormat::eDate);
-            timeDate[i] = osal::toString(times[i], OsalTimeStringFormat::eTimeDate);
-            sortedDateTime[i] = osal::toString(times[i], OsalTimeStringFormat::eSortedDateTime);
+            time[i] = osal::toString(times[i], OsalTimeStringFormat::Time);
+            date[i] = osal::toString(times[i], OsalTimeStringFormat::Date);
+            timeDate[i] = osal::toString(times[i], OsalTimeStringFormat::TimeDate);
+            sortedDateTime[i] = osal::toString(times[i], OsalTimeStringFormat::SortedDateTime);
         }
     }
 
@@ -948,10 +948,10 @@ TEST_CASE("Convert to std::string in C++", "[unit][cpp][time]")
         };
 
         for (std::size_t i = 0; i < timespecs.size(); ++i) {
-            time[i] = osal::toString(timespecs[i], OsalTimeStringFormat::eTime);
-            date[i] = osal::toString(timespecs[i], OsalTimeStringFormat::eDate);
-            timeDate[i] = osal::toString(timespecs[i], OsalTimeStringFormat::eTimeDate);
-            sortedDateTime[i] = osal::toString(timespecs[i], OsalTimeStringFormat::eSortedDateTime);
+            time[i] = osal::toString(timespecs[i], OsalTimeStringFormat::Time);
+            date[i] = osal::toString(timespecs[i], OsalTimeStringFormat::Date);
+            timeDate[i] = osal::toString(timespecs[i], OsalTimeStringFormat::TimeDate);
+            sortedDateTime[i] = osal::toString(timespecs[i], OsalTimeStringFormat::SortedDateTime);
         }
     }
 
@@ -962,35 +962,35 @@ TEST_CASE("Convert to std::string in C++", "[unit][cpp][time]")
         };
 
         for (std::size_t i = 0; i < timevals.size(); ++i) {
-            time[i] = osal::toString(timevals[i], OsalTimeStringFormat::eTime);
-            date[i] = osal::toString(timevals[i], OsalTimeStringFormat::eDate);
-            timeDate[i] = osal::toString(timevals[i], OsalTimeStringFormat::eTimeDate);
-            sortedDateTime[i] = osal::toString(timevals[i], OsalTimeStringFormat::eSortedDateTime);
+            time[i] = osal::toString(timevals[i], OsalTimeStringFormat::Time);
+            date[i] = osal::toString(timevals[i], OsalTimeStringFormat::Date);
+            timeDate[i] = osal::toString(timevals[i], OsalTimeStringFormat::TimeDate);
+            sortedDateTime[i] = osal::toString(timevals[i], OsalTimeStringFormat::SortedDateTime);
         }
     }
 
-    REQUIRE(time[0] == "22:13:02");
-    REQUIRE(date[0] == "28.01.2022");
-    REQUIRE(timeDate[0] == "22:13:02 28.01.2022");
-    REQUIRE(sortedDateTime[0] == "20220128_221302");
+    CHECK(time[0] == "22:13:02");
+    CHECK(date[0] == "28.01.2022");
+    CHECK(timeDate[0] == "22:13:02 28.01.2022");
+    CHECK(sortedDateTime[0] == "20220128_221302");
 
-    REQUIRE(time[1] == "15:05:45");
-    REQUIRE(date[1] == "14.08.1997");
-    REQUIRE(timeDate[1] == "15:05:45 14.08.1997");
-    REQUIRE(sortedDateTime[1] == "19970814_150545");
+    CHECK(time[1] == "15:05:45");
+    CHECK(date[1] == "14.08.1997");
+    CHECK(timeDate[1] == "15:05:45 14.08.1997");
+    CHECK(sortedDateTime[1] == "19970814_150545");
 
-    REQUIRE(time[2] == "21:06:17");
-    REQUIRE(date[2] == "31.12.2001");
-    REQUIRE(timeDate[2] == "21:06:17 31.12.2001");
-    REQUIRE(sortedDateTime[2] == "20011231_210617");
+    CHECK(time[2] == "21:06:17");
+    CHECK(date[2] == "31.12.2001");
+    CHECK(timeDate[2] == "21:06:17 31.12.2001");
+    CHECK(sortedDateTime[2] == "20011231_210617");
 
-    REQUIRE(time[3] == "12:00:00");
-    REQUIRE(date[3] == "11.09.1970");
-    REQUIRE(timeDate[3] == "12:00:00 11.09.1970");
-    REQUIRE(sortedDateTime[3] == "19700911_120000");
+    CHECK(time[3] == "12:00:00");
+    CHECK(date[3] == "11.09.1970");
+    CHECK(timeDate[3] == "12:00:00 11.09.1970");
+    CHECK(sortedDateTime[3] == "19700911_120000");
 
-    REQUIRE(time[4] == "20:20:00");
-    REQUIRE(date[4] == "08.08.1990");
-    REQUIRE(timeDate[4] == "20:20:00 08.08.1990");
-    REQUIRE(sortedDateTime[4] == "19900808_202000");
+    CHECK(time[4] == "20:20:00");
+    CHECK(date[4] == "08.08.1990");
+    CHECK(timeDate[4] == "20:20:00 08.08.1990");
+    CHECK(sortedDateTime[4] == "19900808_202000");
 }


### PR DESCRIPTION
- Updated assertions in ThreadObject.cpp to replace REQUIRE with CHECK for better test flow.
- Modified error checks to use CHECK_FALSE for clarity.
- Changed OsalError enumeration references to match updated naming conventions.
- In time.cpp, replaced REQUIRE with CHECK for consistency in time conversion tests.
- Ensured all assertions maintain the same logical checks while improving readability.